### PR TITLE
snapshot full-service advertising

### DIFF
--- a/contrib/linearize/example-linearize.cfg
+++ b/contrib/linearize/example-linearize.cfg
@@ -6,14 +6,14 @@ host=127.0.0.1
 port=6852
 
 min_height=0
-max_height=6216778
+max_height=6216856
 
 netmagic=f9bcacc4
 genesis=00000063044a9b6cad9015b289de8a86a654d5a916fcaaeeefb5b9408448df40
 input=/home/example/.electron/blocks
 
 hashlist=hashlist.txt
-output_file=/home/example/electron-bootstrap-6216778.dat
+output_file=/home/example/electron-bootstrap-6216856.dat
 
 out_of_order_cache_sz=100000000
 rev_hash_bytes=False

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1448,6 +1448,13 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         .chainparams = chainparams,
         .datadir = args.GetDataDirNet(),
         .adjusted_time_callback = GetAdjustedTime,
+        .snapshot_validation_complete_callback = [&node] {
+            if (node.connman && node.chainman && !node.chainman->m_blockman.IsPruneMode()) {
+                node.connman->RemoveLocalServices(NODE_NETWORK_LIMITED);
+                node.connman->AddLocalServices(NODE_NETWORK);
+                LogPrintf("[snapshot] restored full NODE_NETWORK local service after background validation completed\n");
+            }
+        },
     };
     Assert(!ApplyArgsManOptions(args, chainman_opts)); // no error can happen, already checked in AppInitParameterInteraction
 

--- a/src/kernel/chainstatemanager_opts.h
+++ b/src/kernel/chainstatemanager_opts.h
@@ -39,6 +39,8 @@ struct ChainstateManagerOpts {
     std::optional<uint256> assumed_valid_block{};
     //! If the tip is older than this, the node is considered to be in initial block download.
     std::chrono::seconds max_tip_age{DEFAULT_MAX_TIP_AGE};
+    //! Called after an assumeutxo snapshot has been fully validated by the background chainstate.
+    std::function<void()> snapshot_validation_complete_callback{};
     DBOptions block_tree_db{};
     DBOptions coins_db{};
     CoinsViewOptions coins_view{};

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5618,6 +5618,9 @@ SnapshotCompletionResult ChainstateManager::MaybeCompleteSnapshotValidation(
 
     m_ibd_chainstate->m_disabled = true;
     this->MaybeRebalanceCaches();
+    if (m_options.snapshot_validation_complete_callback) {
+        m_options.snapshot_validation_complete_callback();
+    }
 
     return SnapshotCompletionResult::SUCCESS;
 }


### PR DESCRIPTION
NODE_NETWORK service advertising after assumeutxo background validation completes, while keeping pruned nodes on limited service flags.

Use a chainstate manager completion callback so validation stays decoupled from networking internals.

Refresh the Electron linearize bootstrap example to the mainnet snapshot height and matching output filename.