### PR TITLE
Refine Electron testnet, docs, and fee tests

### DIFF
--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -2,7 +2,7 @@ OpenBSD build guide
 ======================
 (updated for OpenBSD 6.2)
 
-This guide describes how to build bitcoind and command-line utilities on OpenBSD.
+This guide describes how to build electrond and command-line utilities on OpenBSD.
 
 OpenBSD is most commonly used as a server OS, so this guide does not contain instructions for building the GUI.
 
@@ -18,7 +18,7 @@ pkg_add automake # (select highest version, e.g. 1.15)
 pkg_add python # (select highest version, e.g. 3.6)
 pkg_add boost
 
-git clone https://github.com/bitcoin/bitcoin.git
+git clone https://github.com/BlueDragon747/Electron-ELT.git
 ```
 
 See [dependencies.md](dependencies.md) for a complete overview.
@@ -26,7 +26,7 @@ See [dependencies.md](dependencies.md) for a complete overview.
 GCC
 -------
 
-The default C++ compiler that comes with OpenBSD 6.2 is g++ 4.2.1. This version is old (from 2007), and is not able to compile the current version of Bitcoin Core because it has no C++11 support. We'll install a newer version of GCC:
+The default C++ compiler that comes with OpenBSD 6.2 is g++ 4.2.1. This version is old (from 2007), and is not able to compile the current version of Electron Core because it has no C++11 support. We'll install a newer version of GCC:
 
 ```bash
  pkg_add g++
@@ -42,9 +42,9 @@ See "Berkeley DB" in [build-unix.md](build-unix.md#berkeley-db) for instructions
 You cannot use the BerkeleyDB library from ports, for the same reason as boost above (g++/libstd++ incompatibility).
 
 ```bash
-# Pick some path to install BDB to, here we create a directory within the bitcoin directory
-BITCOIN_ROOT=$(pwd)
-BDB_PREFIX="${BITCOIN_ROOT}/db4"
+# Pick some path to install BDB to, here we create a directory within the electron directory
+ELECTRON_ROOT=$(pwd)
+BDB_PREFIX="${ELECTRON_ROOT}/db4"
 mkdir -p $BDB_PREFIX
 
 # Fetch the source and verify that it is not tampered with
@@ -76,7 +76,7 @@ The change will only affect the current shell and processes spawned by it. To
 make the change system-wide, change `datasize-cur` and `datasize-max` in
 `/etc/login.conf`, and reboot.
 
-### Building Bitcoin Core
+### Building Electron Core
 
 **Important**: use `gmake`, not `make`. The non-GNU `make` will exit with a horrible error.
 

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -24,17 +24,17 @@ If you want to build the disk image with `make deploy` (.dmg / optional), you ne
 
 NOTE: Building with Qt4 is still supported, however, could result in a broken UI. Building with Qt5 is recommended.
 
-Build Bitcoin Core
+Build Electron Core
 ------------------------
 
-1. Clone the bitcoin source code and cd into `bitcoin`
+1. Clone the electron source code and cd into `electron`
 
-        git clone https://github.com/bitcoin/bitcoin
-        cd bitcoin
+        git clone https://github.com/BlueDragon747/Electron-ELT
+        cd electron
 
-2.  Build bitcoin-core:
+2.  Build electron-core:
 
-    Configure and build the headless bitcoin binaries as well as the GUI (if Qt is found).
+    Configure and build the headless electron binaries as well as the GUI (if Qt is found).
 
     You can disable the GUI build by passing `--without-gui` to configure.
 
@@ -57,7 +57,7 @@ Electron is now available at `./src/electrond`
 
 Before running, it's recommended you create an RPC configuration file.
 
-    echo -e "rpcuser=bitcoinrpc\nrpcpassword=$(xxd -l 16 -p /dev/urandom)" > "/Users/${USER}/Library/Application Support/Electron/electron.conf"
+    echo -e "rpcuser=electronrpc\nrpcpassword=$(xxd -l 16 -p /dev/urandom)" > "/Users/${USER}/Library/Application Support/Electron/electron.conf"
 
     chmod 600 "/Users/${USER}/Library/Application Support/Electron/electron.conf"
 
@@ -65,25 +65,25 @@ The first time you run electrond, it will start downloading the blockchain. This
 
 You can monitor the download process by looking at the debug.log file:
 
-    tail -f $HOME/Library/Application\ Support/Bitcoin/debug.log
+    tail -f $HOME/Library/Application\ Support/Electron/debug.log
 
 Other commands:
 -------
 
     ./src/electrond -daemon # Starts the Electron daemon.
-    ./src/bitcoin-cli --help # Outputs a list of command-line options.
-    ./src/bitcoin-cli help # Outputs a list of RPC commands when the daemon is running.
+    ./src/electron-cli --help # Outputs a list of command-line options.
+    ./src/electron-cli help # Outputs a list of RPC commands when the daemon is running.
 
 Using Qt Creator as IDE
 ------------------------
-You can use Qt Creator as an IDE, for bitcoin development.
+You can use Qt Creator as an IDE, for electron development.
 Download and install the community edition of [Qt Creator](https://www.qt.io/download/).
 Uncheck everything except Qt Creator during the installation process.
 
 1. Make sure you installed everything through Homebrew mentioned above
 2. Do a proper ./configure --enable-debug
 3. In Qt Creator do "New Project" -> Import Project -> Import Existing Project
-4. Enter "bitcoin-qt" as project name, enter src/qt as location
+4. Enter "electron-qt" as project name, enter src/qt as location
 5. Leave the file selection as it is
 6. Confirm the "summary page"
 7. In the "Projects" tab select "Manage Kits..."

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -1,12 +1,12 @@
 UNIX BUILD NOTES
 ====================
-Some notes on how to build Bitcoin Core in Unix.
+Some notes on how to build Electron Core in Unix.
 
 (for OpenBSD specific instructions, see [build-openbsd.md](build-openbsd.md))
 
 Note
 ---------------------
-Always use absolute paths to configure and compile bitcoin and the dependencies,
+Always use absolute paths to configure and compile electron and the dependencies,
 for example, when specifying the path of the dependency:
 
 	../dist/configure --enable-cxx --disable-shared --with-pic --prefix=$BDB_PREFIX
@@ -24,7 +24,7 @@ make
 make install # optional
 ```
 
-This will build bitcoin-qt as well if the dependencies are met.
+This will build electron-qt as well if the dependencies are met.
 
 Dependencies
 ---------------------
@@ -55,7 +55,7 @@ Memory Requirements
 --------------------
 
 C++ compilers are memory-hungry. It is recommended to have at least 1.5 GB of
-memory available when compiling Bitcoin Core. On systems with less, gcc can be
+memory available when compiling Electron Core. On systems with less, gcc can be
 tuned to conserve memory with additional CXXFLAGS:
 
 
@@ -94,7 +94,7 @@ BerkeleyDB 5.1 or later, which break binary wallet compatibility with the distri
 are based on BerkeleyDB 4.8. If you do not care about wallet compatibility,
 pass `--with-incompatible-bdb` to configure.
 
-See the section "Disable-wallet mode" to build Bitcoin Core without wallet.
+See the section "Disable-wallet mode" to build Electron Core without wallet.
 
 Optional (see --with-miniupnpc and --enable-upnp-default):
 
@@ -107,7 +107,7 @@ ZMQ dependencies (provides ZMQ API 4.x):
 Dependencies for the GUI: Ubuntu & Debian
 -----------------------------------------
 
-If you want to build Bitcoin-Qt, make sure that the required packages for Qt development
+If you want to build electron-qt, make sure that the required packages for Qt development
 are installed. Either Qt 5 or Qt 4 are necessary to build the GUI.
 If both Qt 4 and Qt 5 are installed, Qt 5 will be used. Pass `--with-gui=qt4` to configure to choose Qt4.
 To build without GUI pass `--without-gui`.
@@ -124,7 +124,7 @@ libqrencode (optional) can be installed with:
 
     sudo apt-get install libqrencode-dev
 
-Once these are installed, they will be found by configure and a bitcoin-qt executable will be
+Once these are installed, they will be found by configure and a electron-qt executable will be
 built by default.
 
 Dependency Build Instructions: Fedora
@@ -147,7 +147,7 @@ libqrencode (optional) can be installed with:
 
 Notes
 -----
-The release is built with GCC and then "strip bitcoind" to strip the debug
+The release is built with GCC and then "strip electrond" to strip the debug
 symbols, which reduces the executable size by about 90%.
 
 
@@ -168,10 +168,10 @@ Berkeley DB
 It is recommended to use Berkeley DB 4.8. If you have to build it yourself:
 
 ```bash
-BITCOIN_ROOT=$(pwd)
+ELECTRON_ROOT=$(pwd)
 
-# Pick some path to install BDB to, here we create a directory within the bitcoin directory
-BDB_PREFIX="${BITCOIN_ROOT}/db4"
+# Pick some path to install BDB to, here we create a directory within the electron directory
+BDB_PREFIX="${ELECTRON_ROOT}/db4"
 mkdir -p $BDB_PREFIX
 
 # Fetch the source and verify that it is not tampered with
@@ -186,8 +186,8 @@ cd db-4.8.30.NC/build_unix/
 ../dist/configure --enable-cxx --disable-shared --with-pic --prefix=$BDB_PREFIX
 make install
 
-# Configure Bitcoin Core to use our own-built instance of BDB
-cd $BITCOIN_ROOT
+# Configure Electron Core to use our own-built instance of BDB
+cd $ELECTRON_ROOT
 ./autogen.sh
 ./configure LDFLAGS="-L${BDB_PREFIX}/lib/" CPPFLAGS="-I${BDB_PREFIX}/include/" # (other args...)
 ```
@@ -205,7 +205,7 @@ If you need to build Boost yourself:
 
 Security
 --------
-To help make your bitcoin installation more secure by making certain attacks impossible to
+To help make your electron installation more secure by making certain attacks impossible to
 exploit even if a vulnerability is found, binaries are hardened by default.
 This can be disabled with:
 
@@ -229,7 +229,7 @@ Hardening enables the following features:
 
     To test that you have built PIE executable, install scanelf, part of paxutils, and use:
 
-    	scanelf -e ./bitcoin
+    scanelf -e ./electron
 
     The output should contain:
 
@@ -238,13 +238,13 @@ Hardening enables the following features:
 
 * Non-executable Stack
     If the stack is executable then trivial stack based buffer overflow exploits are possible if
-    vulnerable buffers are found. By default, bitcoin should be built with a non-executable stack
+    vulnerable buffers are found. By default, electron should be built with a non-executable stack
     but if one of the libraries it uses asks for an executable stack or someone makes a mistake
     and uses a compiler extension which requires an executable stack, it will silently build an
     executable without the non-executable stack protection.
 
     To verify that the stack is non-executable after compiling use:
-    `scanelf -e ./bitcoin`
+    `scanelf -e ./electron`
 
     the output should contain:
 	STK/REL/PTL
@@ -254,7 +254,7 @@ Hardening enables the following features:
 
 Disable-wallet mode
 --------------------
-When the intention is to run only a P2P node without a wallet, bitcoin may be compiled in
+When the intention is to run only a P2P node without a wallet, electron may be compiled in
 disable-wallet mode with:
 
     ./configure --disable-wallet
@@ -276,8 +276,8 @@ Setup and Build Example: Arch Linux
 This example lists the steps necessary to setup and build a command line only, non-wallet distribution of the latest changes on Arch Linux:
 
     pacman -S git base-devel boost libevent python
-    git clone https://github.com/bitcoin/bitcoin.git
-    cd bitcoin/
+    git clone https://github.com/BlueDragon747/Electron-ELT.git
+    cd electron/
     ./autogen.sh
     ./configure --disable-wallet --without-gui --without-miniupnpc
     make check
@@ -286,7 +286,7 @@ Note:
 Enabling wallet support requires either compiling against a Berkeley DB newer than 4.8 (package `db`) using `--with-incompatible-bdb`,
 or building and depending on a local version of Berkeley DB 4.8. The readily available Arch Linux packages are currently built using
 `--with-incompatible-bdb` according to the [PKGBUILD](https://projects.archlinux.org/svntogit/community.git/tree/bitcoin/trunk/PKGBUILD).
-As mentioned above, when maintaining portability of the wallet between the standard Bitcoin Core distributions and independently built
+As mentioned above, when maintaining portability of the wallet between the standard Electron Core distributions and independently built
 node software is desired, Berkeley DB 4.8 must be used.
 
 
@@ -334,7 +334,7 @@ For the wallet (optional):
 This will give a warning "configure: WARNING: Found Berkeley DB other
 than 4.8; wallets opened by this build will not be portable!", but as FreeBSD never
 had a binary release, this may not matter. If backwards compatibility
-with 4.8-built Bitcoin Core is needed follow the steps under "Berkeley DB" above.
+with 4.8-built Electron Core is needed follow the steps under "Berkeley DB" above.
 
 Then build using:
 

--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -1,7 +1,7 @@
 WINDOWS BUILD NOTES
 ====================
 
-Below are some notes on how to build Bitcoin Core for Windows.
+Below are some notes on how to build Electron Core for Windows.
 
 Most developers use cross-compilation from Ubuntu to build executables for
 Windows. Cross-compilation is also used to build the release binaries.
@@ -113,6 +113,6 @@ Installation
 After building using the Windows subsystem it can be useful to copy the compiled
 executables to a directory on the windows drive in the same directory structure
 as they appear in the release `.zip` archive. This can be done in the following
-way. This will install to `c:\workspace\bitcoin`, for example:
+way. This will install to `c:\workspace\electron`, for example:
 
-    make install DESTDIR=/mnt/c/workspace/bitcoin
+    make install DESTDIR=/mnt/c/workspace/electron

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -1,117 +1,30 @@
-Bitcoin Core version *0.15.2* is now available from:
+# Electron Core 0.25.2
 
-  <https://bitcoincore.org/bin/bitcoin-core-0.15.2/>
+Electron Core 0.25.2 is a release of the Electron (ELT) full node and wallet,
+rebased onto the Bitcoin Core 25.2 codebase. Source and release binaries:
 
-or
+  https://github.com/BlueDragon747/Electron-ELT
 
-  <https://bitcoin.org/bin/bitcoin-core-0.15.2/>
+Electron is a Blake-256 (8-round) AuxPoW merge-mined coin in the BlakeStream
+family. For network parameters and the full 0.25.2 consensus details, see
+`README.md`.
 
-This is a new minor version release, including various bugfixes and
-performance improvements, as well as updated translations.
+## How to upgrade
 
-Please report bugs using the issue tracker at GitHub:
+Shut down the running wallet/node (`electron-qt` or `electrond`) and wait for it
+to stop completely, then replace the binaries (`electrond`, `electron-qt`,
+`electron-cli`, `electron-tx`, `electron-wallet`) with the 0.25.2 build. Existing
+`wallet.dat` and block/chain data are kept.
 
-  <https://github.com/bitcoin/bitcoin/issues>
+## Notable changes
 
-To receive security and update notifications, please subscribe to:
+- Rebased onto Bitcoin Core 25.2, preserving Electron's network magic, address
+  formats, AuxPoW (chain ID `0x0007`) merge-mining, subsidy, and coinbase
+  maturity rules.
+- Dual wallet support: legacy Berkeley DB `wallet.dat` and descriptor SQLite
+  wallets.
 
-  <https://bitcoincore.org/en/list/announcements/join/>
+## Credits
 
-How to Upgrade
-==============
-
-If you are running an older version, shut it down. Wait until it has completely
-shut down (which might take a few minutes for older versions), then run the 
-installer (on Windows) or just copy over `/Applications/Bitcoin-Qt` (on Mac)
-or `bitcoind`/`bitcoin-qt` (on Linux).
-
-The first time you run version 0.15.0 or higher, your chainstate database will
-be converted to a new format, which will take anywhere from a few minutes to
-half an hour, depending on the speed of your machine.
-
-The file format of `fee_estimates.dat` changed in version 0.15.0. Hence, a
-downgrade from version 0.15 or upgrade to version 0.15 will cause all fee
-estimates to be discarded.
-
-Note that the block database format also changed in version 0.8.0 and there is no
-automatic upgrade code from before version 0.8 to version 0.15.0. Upgrading
-directly from 0.7.x and earlier without redownloading the blockchain is not supported.
-However, as usual, old wallet versions are still supported.
-
-Downgrading warning
--------------------
-
-The chainstate database for this release is not compatible with previous
-releases, so if you run 0.15 and then decide to switch back to any
-older version, you will need to run the old release with the `-reindex-chainstate`
-option to rebuild the chainstate data structures in the old format.
-
-If your node has pruning enabled, this will entail re-downloading and
-processing the entire blockchain.
-
-Compatibility
-==============
-
-Bitcoin Core is extensively tested on multiple operating systems using
-the Linux kernel, macOS 10.8+, and Windows Vista and later. Windows XP is not supported.
-
-Bitcoin Core should also work on most other Unix-like systems but is not
-frequently tested on them.
-
-
-Notable changes
-===============
-
-Denial-of-Service vulnerability CVE-2018-17144
--------------------------------
-
-A denial-of-service vulnerability exploitable by miners has been discovered in
-Bitcoin Core versions 0.14.0 up to 0.16.2. It is recommended to upgrade any of
-the vulnerable versions to 0.15.2 or 0.16.3 as soon as possible.
-
-0.15.2 Change log
-=================
-
-### Build system
-
-- #11995 `9bb1a16` depends: Fix Qt build with XCode 9.2(fanquake)
-- #12946 `93b9a61` depends: Fix Qt build with XCode 9.3(fanquake)
-- #13544 `9fd3e00` depends: Update Qt download url (fanquake)
-- #11847 `cb7ef31` Make boost::multi_index comparators const (sdaftuar)
-
-### Consensus
-- #14247 `4b8a3f5` Fix crash bug with duplicate inputs within a transaction (TheBlueMatt, sdaftuar)
- 
-### RPC
-- #11676 `7af2457` contrib/init: Update openrc-run filename (Luke Dashjr)
-- #11277 `7026845` Fix uninitialized URI in batch RPC requests (Russell Yanofsky)
- 
-### Wallet
-- #11289 `3f1db56` Wrap dumpwallet warning and note scripts aren't dumped (MeshCollider)
-- #11289 `42ea47d` Add wallet backup text to import*, add* and dumpwallet RPCs (MeshCollider)
-- #11590 `6372a75` [Wallet] always show help-line of wallet encryption calls (Jonas Schnelli)
-
-### bitcoin-tx
-
-- #11554 `a69cc07` Sanity-check script sizes in bitcoin-tx (TheBlueMatt)
-
-### Tests
-- #11277 `3a6cdd4` Add test for multiwallet batch RPC calls (Russell Yanofsky)
-- #11647 `1c8c7f8` Add missing batch rpc calls to python coverage logs (Russell Yanofsky)
-- #11277 `1036c43` Add missing multiwallet rpc calls to python coverage logs (Russell Yanofsky)
-- #11277 `305f768` Limit AuthServiceProxyWrapper.\_\_getattr\_\_ wrapping (Russell Yanofsky)
-- #11277 `2eea279` Make AuthServiceProxy.\_batch method usable (Russell Yanofsky)
-
-Credits
-=======
-
-Thanks to everyone who directly contributed to this release:
-
-- fanquake
-- Jonas Schnelli
-- Luke Dashjr
-- Matt Corallo
-- MeshCollider
-- Russell Yanofsky
-- Suhas Daftuar
-- Wladimir J. van der Laan
+Electron Core is built on Bitcoin Core. Thanks to the Bitcoin Core developers
+and contributors, and to the Electron / BlakeStream contributors.

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -242,13 +242,14 @@ public:
         consensus.signet_blocks = false;
         consensus.signet_challenge.clear();
         consensus.nSubsidyHalvingInterval = std::numeric_limits<int>::max();
-        // TODO(blakestream-25.2-activation): testnet mirrors mainnet's BIP34/BIP65/BIP66
-        // disabled-by-far-future-height pattern. See mainnet block above for full
-        // rationale + activation procedure.
-        consensus.BIP34Height = 100000000;
+        // Electron 25.2 testnet is a feature-test/reset network: keep SegWit,
+        // CLTV, strict-DER, BIP34 coinbase height, and Taproot available from
+        // height 1 so DEX atomic-swap and Taproot QA can run before mainnet
+        // activation gates are opened.
+        consensus.BIP34Height = 1;
         consensus.BIP34Hash = uint256{};
-        consensus.BIP65Height = 100000000;
-        consensus.BIP66Height = 100000000;
+        consensus.BIP65Height = 1;
+        consensus.BIP66Height = 1;
         // TODO(blakestream-25.2-activation): CSV (BIP68/112/113) ALWAYS_ACTIVE on
         // Blakestream family — atomic-swap timeout primitive. Do NOT change.
         consensus.CSVHeight = 1;
@@ -257,24 +258,21 @@ public:
         // waiting on the 0.15.21 mainnet activation. Do NOT change.
         consensus.SegwitHeight = 1;
         consensus.MinBIP9WarningHeight = 0;
-        // Match Electron-ELT-0.15.21 testnet's released powLimit.
-        consensus.powLimit = uint256S("0x000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+        // Private 25.2 feature-testnet uses regtest-style PoW so local CPU
+        // pool tests can advance blocks quickly while mainnet stays unchanged.
+        consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 30 * 60;
         consensus.nPowTargetSpacing = 60;
         consensus.fPowAllowMinDifficultyBlocks = true;
-        consensus.fPowNoRetargeting = false;
+        consensus.fPowNoRetargeting = true;
         consensus.nRuleChangeActivationThreshold = 27;
         consensus.nMinerConfirmationWindow = 30;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 1199145601;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = 1230767999;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].min_activation_height = 0;
-        // TODO(blakestream-25.2-activation): testnet Taproot — when mainnet Taproot
-        // activation values get set (post-0.15.21-SegWit), set testnet to a slightly
-        // earlier window so testnet covers activation before mainnet. Currently
-        // NEVER_ACTIVE. See mainnet block above for full procedure.
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].bit = 2;
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE;
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].min_activation_height = 0;
 

--- a/src/test/amount_tests.cpp
+++ b/src/test/amount_tests.cpp
@@ -83,6 +83,13 @@ BOOST_AUTO_TEST_CASE(GetFeeTest)
     // some more integer checks
     BOOST_CHECK(CFeeRate(CAmount(26), 789) == CFeeRate(32));
     BOOST_CHECK(CFeeRate(CAmount(27), 789) == CFeeRate(34));
+    BOOST_CHECK(CFeeRate(CAmount(-26), 789) == CFeeRate(-32));
+    BOOST_CHECK(CFeeRate(CAmount(-27), 789) == CFeeRate(-34));
+    // Saturate before scaling would overflow CAmount.
+    BOOST_CHECK(CFeeRate(std::numeric_limits<CAmount>::max(), 1) == CFeeRate(std::numeric_limits<CAmount>::max()));
+    BOOST_CHECK(CFeeRate(std::numeric_limits<CAmount>::min(), 1) == CFeeRate(std::numeric_limits<CAmount>::min()));
+    BOOST_CHECK(CFeeRate(std::numeric_limits<CAmount>::max(), 1000) == CFeeRate(std::numeric_limits<CAmount>::max()));
+    BOOST_CHECK(CFeeRate(std::numeric_limits<CAmount>::min(), 1000) == CFeeRate(std::numeric_limits<CAmount>::min()));
     // Maximum size in bytes, should not crash
     CFeeRate(MAX_MONEY, std::numeric_limits<uint32_t>::max()).GetFeePerK();
 }


### PR DESCRIPTION
Refresh public build and release notes docs with Electron command names, repository URL, RPC config examples, and the 0.25.2 release summary.

Set testnet BIP34, BIP65, and BIP66 activation heights to 1, keep SegWit active from genesis, and make Taproot always active for reset-network QA.

Use regtest-style proof-of-work and no retargeting on testnet so local mining, pool, and swap tests can advance blocks quickly without changing mainnet parameters.

Add fee-rate constructor coverage for zero-size inputs, negative remainders, and CAmount min/max saturation.