### PR TITLE
Include default version in AuxPoW bit guard

### DIFF
--- a/src/primitives/pureheader.h
+++ b/src/primitives/pureheader.h
@@ -27,6 +27,10 @@ public:
     static constexpr int32_t VERSION_AUXPOW = (1 << 8);
     static constexpr int32_t VERSION_CHAIN_START = (1 << 16);
     static constexpr int32_t VERSION_CHAIN_MASK = (0xFF << 16);
+    // AuxPoW metadata is part of the block version word and is unavailable
+    // for BIP9 signaling.
+    static constexpr int32_t VERSION_AUXPOW_RESERVED_MASK =
+        BLOCK_VERSION_DEFAULT | VERSION_AUXPOW | VERSION_CHAIN_MASK;
 
     int32_t nVersion;
     uint256 hashPrevBlock;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2001,7 +2001,7 @@ private:
         if (params.nAuxpowChainId == 0) return false;
 
         const int32_t mask{int32_t{1} << bit};
-        return (mask & (CPureBlockHeader::VERSION_AUXPOW | CPureBlockHeader::VERSION_CHAIN_MASK)) != 0;
+        return (mask & CPureBlockHeader::VERSION_AUXPOW_RESERVED_MASK) != 0;
     }
 
 public:


### PR DESCRIPTION
Treat BLOCK_VERSION_DEFAULT as reserved when checking version bits that conflict with AuxPoW metadata, so BIP9 deployments cannot reuse the default block-version bit alongside AuxPoW chain-id fields.