### PR TITLE
Updates the 0.25.2 release documentation and Electrum wallet build helper.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,18 @@ git checkout electron-25.2-auxpow-port
 For most users, downloading a tested release artifact from GitHub Releases is
 the simplest path. Use `build.sh` to build release artifacts locally.
 
+## UPnP / miniupnpc Build Profiles
+
+UPnP is only for desktop or home-router nodes that need automatic inbound P2P
+port mapping. Nodes still sync normally through outbound peers without UPnP.
+
+Pool, explorer, server, and Docker daemon builds should disable UPnP with
+`--without-miniupnpc` so the binary has no `libminiupnpc.so.*` runtime
+dependency.
+
+UPnP-enabled Ubuntu builds need `libminiupnpc-dev` at build time and the matching
+`libminiupnpc` runtime package on the target host.
+
 ## Upgrade Notes
 
 Before starting Electron Core 0.25.2 on an existing data directory, close the
@@ -152,10 +164,10 @@ Other options:
 ```
 
 
-<!-- BEGIN electrium-build -->
-### Electrium Wallet
+<!-- BEGIN electrum-build -->
+### Electrum Wallet
 
-Build the Electron ([Electrium](https://github.com/SidGrip/Blakestream-Electrium)) wallet by
+Build the Electron ([Electrum](https://github.com/BlueDragon747/Blakestream-Electrum)) wallet by
 choosing a target (linux/windows build in an **amd64** container, so any amd64 Docker host — Linux,
 Windows, or an Intel Mac — can build either; only the macOS app needs a Mac):
 
@@ -166,13 +178,13 @@ Windows, or an Intel Mac — can build either; only the macOS app needs a Mac):
 ./build-electrum.sh all        # everything buildable on this host
 ```
 
-Artifacts land in `outputs/Electrium/ELT/`, named `Electrium-ELT-<version>`.
+Artifacts land in `outputs/Electrum/ELT/`, named `Electrum-ELT-<version>`.
 
 The wallet builder is the shared multicoin repo
-**[SidGrip/Blakestream-Electrium](https://github.com/SidGrip/Blakestream-Electrium)** — it also builds
+**[BlueDragon747/Blakestream-Electrum](https://github.com/BlueDragon747/Blakestream-Electrum)** — it also builds
 all six BlakeStream wallets at once (`build-single-wallets.sh`) and the ElectrumX **server** Docker
 image (`build-electrumx.sh`). `build-electrum.sh` auto-clones it when no local checkout is found.
-<!-- END electrium-build -->
+<!-- END electrum-build -->
 
 ## Platform Build Instructions
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,29 @@ Other options:
   --jobs N          Parallel make jobs
 ```
 
+
+<!-- BEGIN electrium-build -->
+### Electrium Wallet
+
+Build the Electron ([Electrium](https://github.com/SidGrip/Blakestream-Electrium)) wallet by
+choosing a target (linux/windows build in an **amd64** container, so any amd64 Docker host — Linux,
+Windows, or an Intel Mac — can build either; only the macOS app needs a Mac):
+
+```bash
+./build-electrum.sh linux      # Linux AppImage    (amd64 Docker host)
+./build-electrum.sh windows    # Windows .exe      (amd64 Docker host)
+./build-electrum.sh macos      # macOS .dmg/.app   (on a Mac)
+./build-electrum.sh all        # everything buildable on this host
+```
+
+Artifacts land in `outputs/Electrium/ELT/`, named `Electrium-ELT-<version>`.
+
+The wallet builder is the shared multicoin repo
+**[SidGrip/Blakestream-Electrium](https://github.com/SidGrip/Blakestream-Electrium)** — it also builds
+all six BlakeStream wallets at once (`build-single-wallets.sh`) and the ElectrumX **server** Docker
+image (`build-electrumx.sh`). `build-electrum.sh` auto-clones it when no local checkout is found.
+<!-- END electrium-build -->
+
 ## Platform Build Instructions
 
 ### Native Linux

--- a/build-electrum.sh
+++ b/build-electrum.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Build THIS coin's Electrium 0.25.2 wallet for an explicitly chosen target, by
-# delegating to the shared multicoin builder (SidGrip/Blakestream-Electrium).
+# Build THIS coin's Electrum 0.25.2 wallet for an explicitly chosen target, by
+# delegating to the shared multicoin builder (BlueDragon747/Blakestream-Electrum).
 #
 # The OS is NOT auto-detected: Linux and Windows are both built in containers, so
 # any Docker host (Linux, Windows, or Intel macOS) can build either. Only the
@@ -20,7 +20,7 @@ usage() {
     cat <<EOF
 usage: ./build-electrum.sh <linux|windows|macos|wheel|all>
 
-Build the ${COIN_NAME} (${COIN_CODE}) Electrium wallet. Choose the target with a
+Build the ${COIN_NAME} (${COIN_CODE}) Electrum wallet. Choose the target with a
 flag (the OS is NOT auto-detected — linux/windows build in an amd64 container, so
 any amd64 Docker host — Linux, Windows, or an Intel Mac — can build either):
 
@@ -32,10 +32,10 @@ any amd64 Docker host — Linux, Windows, or an Intel Mac — can build either):
                      (amd64 Docker host -> linux + windows;  macOS -> + macos)
 
 Environment:
-  ELECTRIUM_SOURCE         Existing SidGrip/Blakestream-Electrium checkout to use.
-  ELECTRIUM_REPO_URL       Git URL cloned if no local checkout is found.
-  ELECTRIUM_WORKSPACE_ROOT Generated variant workspaces.
-  ELECTRIUM_ARTIFACT_ROOT  Output artifact root.
+  ELECTRUM_SOURCE         Existing BlueDragon747/Blakestream-Electrum checkout to use.
+  ELECTRUM_REPO_URL       Git URL cloned if no local checkout is found.
+  ELECTRUM_WORKSPACE_ROOT Generated variant workspaces.
+  ELECTRUM_ARTIFACT_ROOT  Output artifact root.
 EOF
 }
 
@@ -58,20 +58,20 @@ is_mac()        { [ "$(uname -s)" = "Darwin" ]; }
 amd64_native()  { case "$(uname -m)" in x86_64|amd64) return 0 ;; *) return 1 ;; esac; }
 container_host() { have_docker && amd64_native; }
 
-find_electrium_source() {
-    if [ -n "${ELECTRIUM_SOURCE:-}" ]; then printf '%s\n' "$ELECTRIUM_SOURCE"; return; fi
+find_electrum_source() {
+    if [ -n "${ELECTRUM_SOURCE:-}" ]; then printf '%s\n' "$ELECTRUM_SOURCE"; return; fi
     local candidate
     for candidate in \
-        "$REPO_ROOT"/../Blakestream-Electrium \
-        "$REPO_ROOT"/../Blakestream-Electrium-0.25.2 \
-        /mnt/ram-build/Blakestream-Electrium-0.25.2 \
-        /home/sid/Blakestream-Electrium-0.25.2 \
-        /home/sid/Blakestream-Electrium ; do
+        "$REPO_ROOT"/../Blakestream-Electrum \
+        "$REPO_ROOT"/../Blakestream-Electrum-0.25.2 \
+        /mnt/ram-build/Blakestream-Electrum-0.25.2 \
+        /home/sid/Blakestream-Electrum-0.25.2 \
+        /home/sid/Blakestream-Electrum ; do
         if [ -x "$candidate/scripts/build_wallet_variant.sh" ]; then printf '%s\n' "$candidate"; return; fi
     done
     local cache_root="${XDG_CACHE_HOME:-$HOME/.cache}/blakestream"
-    local source_root="$cache_root/Blakestream-Electrium"
-    local repo_url="${ELECTRIUM_REPO_URL:-https://github.com/SidGrip/Blakestream-Electrium.git}"
+    local source_root="$cache_root/Blakestream-Electrum"
+    local repo_url="${ELECTRUM_REPO_URL:-https://github.com/BlueDragon747/Blakestream-Electrum.git}"
     if [ ! -x "$source_root/scripts/build_wallet_variant.sh" ]; then
         mkdir -p "$cache_root"
         git clone --depth 1 "$repo_url" "$source_root"
@@ -79,12 +79,12 @@ find_electrium_source() {
     printf '%s\n' "$source_root"
 }
 
-ELECTRIUM_ROOT="$(find_electrium_source)"
-[ -x "$ELECTRIUM_ROOT/scripts/build_wallet_variant.sh" ] || {
-    echo "ERROR: missing Electrium builder at $ELECTRIUM_ROOT/scripts/build_wallet_variant.sh" >&2; exit 1; }
+ELECTRUM_ROOT="$(find_electrum_source)"
+[ -x "$ELECTRUM_ROOT/scripts/build_wallet_variant.sh" ] || {
+    echo "ERROR: missing Electrum builder at $ELECTRUM_ROOT/scripts/build_wallet_variant.sh" >&2; exit 1; }
 
-WORKSPACE_ROOT="${ELECTRIUM_WORKSPACE_ROOT:-$REPO_ROOT/outputs/Electrium/workspaces}"
-ARTIFACT_ROOT="${ELECTRIUM_ARTIFACT_ROOT:-$REPO_ROOT/outputs/Electrium}"
+WORKSPACE_ROOT="${ELECTRUM_WORKSPACE_ROOT:-$REPO_ROOT/outputs/Electrum/workspaces}"
+ARTIFACT_ROOT="${ELECTRUM_ARTIFACT_ROOT:-$REPO_ROOT/outputs/Electrum}"
 
 # Build one target after checking this host can do it.
 run_one() {
@@ -92,12 +92,12 @@ run_one() {
     case "$t" in
         macos|mac)
             is_mac || { echo "macos must be built ON macOS (no cross-compile). From a Docker host, SSH-dispatch:" >&2
-                        echo "  $ELECTRIUM_ROOT/scripts/build-single-wallets.sh macos $COIN_CODE" >&2; return 2; } ;;
+                        echo "  $ELECTRUM_ROOT/scripts/build-single-wallets.sh macos $COIN_CODE" >&2; return 2; } ;;
         linux|appimage|windows|win)
             have_docker || { echo "$t needs Docker on this host." >&2; return 2; }
             amd64_native || echo "  warning: $t builds an amd64 container; on this $(uname -m) host it runs under slow/flaky emulation." >&2 ;;
     esac
-    "$ELECTRIUM_ROOT/scripts/build_wallet_variant.sh" "$COIN_CODE" "$t" "$WORKSPACE_ROOT" "$ARTIFACT_ROOT"
+    "$ELECTRUM_ROOT/scripts/build_wallet_variant.sh" "$COIN_CODE" "$t" "$WORKSPACE_ROOT" "$ARTIFACT_ROOT"
 }
 
 if [ "$TARGET" = "all" ]; then
@@ -113,4 +113,4 @@ if [ -d "$ARTIFACT_ROOT/$COIN_CODE" ]; then
     ( cd "$ARTIFACT_ROOT/$COIN_CODE" \
         && find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 -r sha256sum > SHA256SUMS )
 fi
-echo "Electrium ${COIN_CODE} artifacts: $ARTIFACT_ROOT/$COIN_CODE"
+echo "Electrum ${COIN_CODE} artifacts: $ARTIFACT_ROOT/$COIN_CODE"

--- a/build-electrum.sh
+++ b/build-electrum.sh
@@ -1,73 +1,116 @@
 #!/usr/bin/env bash
+# Build THIS coin's Electrium 0.25.2 wallet for an explicitly chosen target, by
+# delegating to the shared multicoin builder (SidGrip/Blakestream-Electrium).
+#
+# The OS is NOT auto-detected: Linux and Windows are both built in containers, so
+# any Docker host (Linux, Windows, or Intel macOS) can build either. Only the
+# macOS app needs a native Mac. Pick the target with a flag.
+#
+# CANONICAL COPY: this file lives in the multicoin builder at
+#   contrib/coin-repo/build-electrum.sh
+# and is synced into every coin repo by scripts/sync-build-electrum.sh.
+# Edit it there, not in the per-coin copies.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$REPO_ROOT/electrum/coin.env"
+# shellcheck disable=SC1091
+source "$REPO_ROOT/electrum/coin.env"   # COIN_CODE, COIN_NAME
 
 usage() {
     cat <<EOF
-usage: ./build-electrum.sh [wheel|appimage|both]
+usage: ./build-electrum.sh <linux|windows|macos|wheel|all>
 
-Build the ${COIN_NAME} Electrium wallet variant.
+Build the ${COIN_NAME} (${COIN_CODE}) Electrium wallet. Choose the target with a
+flag (the OS is NOT auto-detected — linux/windows build in an amd64 container, so
+any amd64 Docker host — Linux, Windows, or an Intel Mac — can build either):
+
+  linux | appimage   Linux AppImage           (docker; amd64 Docker host)
+  windows | win      Windows .exe (+ bundle)   (docker + wine; amd64 Docker host)
+  macos | mac        macOS .dmg/.app           (native; macOS host only)
+  wheel              Python sdist + wheel      (local venv)
+  all                every target buildable on THIS host
+                     (amd64 Docker host -> linux + windows;  macOS -> + macos)
 
 Environment:
-  ELECTRIUM_SOURCE        Existing Blakestream-Electrium-0.25.2 checkout.
-  ELECTRIUM_REPO_URL      Git URL used if no local source checkout exists.
+  ELECTRIUM_SOURCE         Existing SidGrip/Blakestream-Electrium checkout to use.
+  ELECTRIUM_REPO_URL       Git URL cloned if no local checkout is found.
   ELECTRIUM_WORKSPACE_ROOT Generated variant workspaces.
   ELECTRIUM_ARTIFACT_ROOT  Output artifact root.
 EOF
 }
 
-TARGET="${1:-wheel}"
-case "$TARGET" in
-    wheel|appimage|both) ;;
+case "${1:-}" in
     -h|--help) usage; exit 0 ;;
-    *) usage >&2; exit 1 ;;
+    "")        echo "error: choose a target (the OS is not auto-detected)" >&2; usage >&2; exit 1 ;;
+esac
+# macOS ships bash 3.2 (no ${var,,}); use tr.
+TARGET="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+case "$TARGET" in
+    linux|appimage|windows|win|macos|mac|wheel|all) ;;
+    *) echo "unknown target: $1" >&2; usage >&2; exit 1 ;;
 esac
 
-find_electrium_source() {
-    if [[ -n "${ELECTRIUM_SOURCE:-}" ]]; then
-        printf '%s\n' "$ELECTRIUM_SOURCE"
-        return
-    fi
+have_docker()   { command -v docker >/dev/null 2>&1; }
+is_mac()        { [ "$(uname -s)" = "Darwin" ]; }
+# linux/windows build inside an amd64 container — native on any amd64 host
+# (incl. Intel Macs). On Apple Silicon it would run under slow/flaky amd64
+# emulation, so `all` won't pick it automatically there (explicit still works).
+amd64_native()  { case "$(uname -m)" in x86_64|amd64) return 0 ;; *) return 1 ;; esac; }
+container_host() { have_docker && amd64_native; }
 
+find_electrium_source() {
+    if [ -n "${ELECTRIUM_SOURCE:-}" ]; then printf '%s\n' "$ELECTRIUM_SOURCE"; return; fi
     local candidate
     for candidate in \
-        "$REPO_ROOT/../Blakestream-Electrium-0.25.2" \
-        "/home/sid/Blakestream-Electrium-0.25.2"
-    do
-        if [[ -x "$candidate/scripts/build_wallet_variant.sh" ]]; then
-            printf '%s\n' "$candidate"
-            return
-        fi
+        "$REPO_ROOT"/../Blakestream-Electrium \
+        "$REPO_ROOT"/../Blakestream-Electrium-0.25.2 \
+        /mnt/ram-build/Blakestream-Electrium-0.25.2 \
+        /home/sid/Blakestream-Electrium-0.25.2 \
+        /home/sid/Blakestream-Electrium ; do
+        if [ -x "$candidate/scripts/build_wallet_variant.sh" ]; then printf '%s\n' "$candidate"; return; fi
     done
-
     local cache_root="${XDG_CACHE_HOME:-$HOME/.cache}/blakestream"
-    local source_root="$cache_root/Blakestream-Electrium-0.25.2"
-    local repo_url="${ELECTRIUM_REPO_URL:-https://github.com/SidGrip/Blakestream-Electrium-0.25.2.git}"
-    if [[ ! -x "$source_root/scripts/build_wallet_variant.sh" ]]; then
+    local source_root="$cache_root/Blakestream-Electrium"
+    local repo_url="${ELECTRIUM_REPO_URL:-https://github.com/SidGrip/Blakestream-Electrium.git}"
+    if [ ! -x "$source_root/scripts/build_wallet_variant.sh" ]; then
         mkdir -p "$cache_root"
-        git clone "$repo_url" "$source_root"
+        git clone --depth 1 "$repo_url" "$source_root"
     fi
     printf '%s\n' "$source_root"
 }
 
 ELECTRIUM_ROOT="$(find_electrium_source)"
-if [[ ! -x "$ELECTRIUM_ROOT/scripts/build_wallet_variant.sh" ]]; then
-    echo "ERROR: missing Electrium builder at $ELECTRIUM_ROOT/scripts/build_wallet_variant.sh" >&2
-    exit 1
-fi
+[ -x "$ELECTRIUM_ROOT/scripts/build_wallet_variant.sh" ] || {
+    echo "ERROR: missing Electrium builder at $ELECTRIUM_ROOT/scripts/build_wallet_variant.sh" >&2; exit 1; }
 
 WORKSPACE_ROOT="${ELECTRIUM_WORKSPACE_ROOT:-$REPO_ROOT/outputs/Electrium/workspaces}"
 ARTIFACT_ROOT="${ELECTRIUM_ARTIFACT_ROOT:-$REPO_ROOT/outputs/Electrium}"
 
-"$ELECTRIUM_ROOT/scripts/build_wallet_variant.sh" "$COIN_CODE" "$TARGET" "$WORKSPACE_ROOT" "$ARTIFACT_ROOT"
+# Build one target after checking this host can do it.
+run_one() {
+    local t="$1"
+    case "$t" in
+        macos|mac)
+            is_mac || { echo "macos must be built ON macOS (no cross-compile). From a Docker host, SSH-dispatch:" >&2
+                        echo "  $ELECTRIUM_ROOT/scripts/build-single-wallets.sh macos $COIN_CODE" >&2; return 2; } ;;
+        linux|appimage|windows|win)
+            have_docker || { echo "$t needs Docker on this host." >&2; return 2; }
+            amd64_native || echo "  warning: $t builds an amd64 container; on this $(uname -m) host it runs under slow/flaky emulation." >&2 ;;
+    esac
+    "$ELECTRIUM_ROOT/scripts/build_wallet_variant.sh" "$COIN_CODE" "$t" "$WORKSPACE_ROOT" "$ARTIFACT_ROOT"
+}
 
-if [[ -d "$ARTIFACT_ROOT/$COIN_CODE" ]]; then
-    (
-        cd "$ARTIFACT_ROOT/$COIN_CODE"
-        find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 -r sha256sum > SHA256SUMS
-    )
+if [ "$TARGET" = "all" ]; then
+    built=0
+    if container_host; then run_one appimage; run_one windows; built=1; fi   # amd64 Docker host
+    if is_mac;         then run_one macos;                     built=1; fi   # native mac app
+    [ "$built" = "1" ] || { echo "nothing buildable automatically here: need an amd64 Docker host (linux/windows) or macOS (mac app). Pass an explicit target to force." >&2; exit 1; }
+else
+    run_one "$TARGET"
 fi
 
+if [ -d "$ARTIFACT_ROOT/$COIN_CODE" ]; then
+    ( cd "$ARTIFACT_ROOT/$COIN_CODE" \
+        && find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 -r sha256sum > SHA256SUMS )
+fi
 echo "Electrium ${COIN_CODE} artifacts: $ARTIFACT_ROOT/$COIN_CODE"


### PR DESCRIPTION
- Point Electrum wallet builder references to BlueDragon747/Blakestream-Electrum
- Fix Electrum spelling in README files and build-electrum.sh
- Keep UPnP / miniupnpc build profile guidance concise
- Preserve existing 0.25.2 release artifact staging